### PR TITLE
[fix] 훈련사 프로필 api 응답

### DIFF
--- a/src/main/java/com/mungtrainer/mtserver/auth/controller/AuthController.java
+++ b/src/main/java/com/mungtrainer/mtserver/auth/controller/AuthController.java
@@ -15,6 +15,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -162,6 +163,9 @@ public class AuthController {
   @GetMapping("/check")
   public ResponseEntity<CheckResponse> checkAuthentication(
       @AuthenticationPrincipal CustomUserDetails principal) {
+    if (principal == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+    }
     return ResponseEntity.ok(CheckResponse.builder()
                                           .userId(principal.getUserId())
                                           .role(principal.getRole())


### PR DESCRIPTION
- 훈련사 프로필 api 응답 수정
- 로그인 체크 null -> UNAUTHORIZED

## 🔗 관련 이슈
<!-- 관련된 이슈가 있다면 아래와 같이 작성해주세요 -->
Fixes #66  (Fix된 이슈를 선택합니다. #은 지우지마시고 바로 #번호 로 입력해주세요)
Closes #66  (Close할 이슈를 #은 지우지마시고 바로 #번호 로 입력해주세요)
